### PR TITLE
created the README-DBPlan of ChatSpace

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,28 +27,28 @@ Things you may want to cover:
 ## usersテーブル
 |Column|Type|Options|
 |------|----|-------|
-|email|strings|null: false, unique: false|
-|password|strings|null: false|
-|name|strings|null: false, unique: false|
-|group_id|integer|null: false, foreign_key: true|
+|email|string|null: false, unique: false|
+|password|string|null: false|
+|name|string|null: false, unique: false|
 ### Association
 - has_many :groups, through: :users_groups
+- has_many :users_groups
 - has_many :messages
 
 ## groupsテーブル
 |Column|Type|Options|
 |------|----|-------|
-|groupname|strings|
-|user_id|integer|null: false, foreign_key: true|
+|name|string|null: false|
 ### Association
 - has_many :users, through: :users_groups
+- has_many :users_groups
 - has_many :messages
 
 ## messagesテーブル
 |Column|Type|Options|
 |------|----|-------|
-|text|text|null: false|
-|image|integer|null: false|
+|text|text||
+|image|text||
 |user_id|integer|null: false, foreign_key: true|
 |group_id|integer|null: false, foreign_key: true|
 ### Association
@@ -59,7 +59,7 @@ Things you may want to cover:
 |Column|Type|Options|
 |------|----|-------|
 |user_id|integer|null: false, foreign_key: true|
-|tweet_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
 ### Association
 - belongs_to :user
-- belongs_to :message
+- belongs_to :group

--- a/README.md
+++ b/README.md
@@ -22,3 +22,44 @@ Things you may want to cover:
 * Deployment instructions
 
 * ...
+
+# ChatSpace DB設計
+## usersテーブル
+|Column|Type|Options|
+|------|----|-------|
+|email|strings|null: false, unique: false|
+|password|strings|null: false|
+|name|strings|null: false, unique: false|
+|group_id|integer|null: false, foreign_key: true|
+### Association
+- has_many :groups, through: :users_groups
+- has_many :messages
+
+## groupsテーブル
+|Column|Type|Options|
+|------|----|-------|
+|groupname|strings|
+|user_id|integer|null: false, foreign_key: true|
+### Association
+- has_many :users, through: :users_groups
+- has_many :messages
+
+## messagesテーブル
+|Column|Type|Options|
+|------|----|-------|
+|text|text|null: false|
+|image|integer|null: false|
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
+### Association
+- belongs_to :user
+- belongs_to :group
+
+## users_groupsテーブル
+|Column|Type|Options|
+|------|----|-------|
+|user_id|integer|null: false, foreign_key: true|
+|tweet_id|integer|null: false, foreign_key: true|
+### Association
+- belongs_to :user
+- belongs_to :message


### PR DESCRIPTION
＃What
「README.md」にて、ChatSpaceのDB設計を記載しました。
テーブルは、「messages」「users」「groups」「中間テーブル　users_groups」テーブルを
作成。

＃Why
データベース設計を開発の前段階にすることにより、効率よくデータベースの管理が行えるため。